### PR TITLE
Changes data type in the firmware update event handler

### DIFF
--- a/Software/Particle_SW/stationfirmware/.vscode/settings.json
+++ b/Software/Particle_SW/stationfirmware/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
     "particle.targetDevice": "mn_devCamel",
-    "particle.firmwareVersion": "3.1.0",
+    "particle.firmwareVersion": "3.0.0",
     "particle.targetPlatform": "argon"
 }

--- a/Software/Particle_SW/stationfirmware/.vscode/settings.json
+++ b/Software/Particle_SW/stationfirmware/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
     "particle.targetDevice": "mn_devCamel",
-    "particle.firmwareVersion": "3.0.0",
+    "particle.firmwareVersion": "3.2.0",
     "particle.targetPlatform": "argon"
 }

--- a/Software/Particle_SW/stationfirmware/.vscode/settings.json
+++ b/Software/Particle_SW/stationfirmware/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "particle.targetDevice": "mn_devCamel",
+    "particle.firmwareVersion": "3.1.0",
+    "particle.targetPlatform": "argon"
+}

--- a/Software/Particle_SW/stationfirmware/src/checkinfirmware.ino
+++ b/Software/Particle_SW/stationfirmware/src/checkinfirmware.ino
@@ -149,8 +149,10 @@
  *       sets the Error-Response-Topic. After an error will try to get new token only when 
  *       an RFID card is presented.
  *  2.4  Corrected reporting to FDB on JSON parsing error
+ *  2.5  Changed type of "data" parameter in firmwareupdatehandler() from "int" to "unsigned int".  The
+ *          code now compiles under OS 3.1 and OS 3.2
 ************************************************************************/
-#define MN_FIRMWARE_VERSION 2.4
+#define MN_FIRMWARE_VERSION 2.5
 
 // Our UTILITIES
 #include "mnutils.h"
@@ -246,7 +248,7 @@ char * strcat_safe( const char *str1, const char *str2 )
 // Called by Particle OS when a firmware update is about to begin
 //
 // Will put a message on the LCD screen and turn on the red LED
-void firmwareupdatehandler(system_event_t event, int data) {
+void firmwareupdatehandler(system_event_t event, unsigned int data) {
     switch (data) {
     case firmware_update_begin:
         writeToLCD("Firmware update","in progress");


### PR DESCRIPTION
The code now compiles under Particle OS 3.1 and 3.2.  I regression tested all types of the station under OS 3.2 and this change and everything seems to work normally.  This code can be the jumpoff point for the MOD station modifications.