### PR TITLE
Amilia

### DIFF
--- a/Software/Particle_SW/ParticleCloudSoftware/webhooks.txt
+++ b/Software/Particle_SW/ParticleCloudSoftware/webhooks.txt
@@ -31,6 +31,7 @@ file.
     "name": "AmiliaClientByMemberNumber",
     "event": "ezfClientByMemberNumber",
     "responseTopic": "{{PARTICLE_DEVICE_ID}}ezfClientByMemberNumber",
+    "errorResponseTopic": "{{PARTICLE_DEVICE_ID}}ezfClientByMemberNumber",
     "url": "https://www.amilia.com/api/V3/en/org/makernexus/persons/{{{memberNumber}}}",
     "requestType": "GET",
     "noDefaults": true,
@@ -40,6 +41,12 @@ file.
         "ez-page-number": "1",
         "Accept": "application/json",
         "Authorization": "Bearer {{{access_token}}}"
+    },
+    "todayCounters": {
+        "date": "20230623",
+        "success": 10,
+        "error": 34,
+        "sleep": 7
     }
 }
 

--- a/Software/Particle_SW/stationfirmware/src/checkinfirmware.ino
+++ b/Software/Particle_SW/stationfirmware/src/checkinfirmware.ino
@@ -158,8 +158,9 @@
  *  2.91   added test for http 404 message to handle this gracefully (for Amilia)
  *  2.92    changed logging into message from EZ Facility to Amilia
  *  2.93    added code to prevent bad member number from re-querying over and over.
+ *  2.94    cleaned up extra stuff that I tried but did not fix the problem.
 ************************************************************************/
-#define MN_FIRMWARE_VERSION 2.93
+#define MN_FIRMWARE_VERSION 2.94
 
 // Our UTILITIES
 #include "mnutils.h"
@@ -903,8 +904,8 @@ void ezfReceiveClientByMemberNumber (const char *event, const char *data)  {
 
         // extra stuff added to 2.92 to see if we can better fake it out.
         //  testing shows that this stuff doesn't seem to matter.
-        g_clientInfo.isError = false;   // XXXX does this matter? Doesn't seem so!
-        JSONParseError = "0";   // does this matter?  Doesn't seem so!
+        //  g_clientInfo.isError = false;   // XXXX does this matter? Doesn't seem so!
+        //  JSONParseError = "0";   // does this matter?  Doesn't seem so!
         // end of extra stuff ...
 
         return;

--- a/Software/Particle_SW/stationfirmware/src/checkinfirmware.ino
+++ b/Software/Particle_SW/stationfirmware/src/checkinfirmware.ino
@@ -896,7 +896,7 @@ void ezfReceiveClientByMemberNumber (const char *event, const char *data)  {
     // XXXX check to see if the response was a non-json error message    
     String receivedData = String(data);
     if(receivedData.startsWith("error status 404")) {
-        g_clientInfo.clientID = 1;  // clientID of 0 has special meaning; don't use in fakeout
+        g_clientInfo.clientID = 0;  // clientID of 0 has special meaning
         g_clientInfo.firstName = "Member not found";
         g_clientInfo.memberNumber = receivedMemberNumberFromQuery;
         g_clientInfo.isValid = true;

--- a/Software/Particle_SW/stationfirmware/src/checkinfirmware.ino
+++ b/Software/Particle_SW/stationfirmware/src/checkinfirmware.ino
@@ -155,8 +155,9 @@
  *  2.8  package checking is now done in all upper case
  *  2.9  changes to support pictureURL coming from the CRM and being passed to the FDB. Needed for Amilia support.
  *       Fixed bug #25
+ *  2.91   added test for http 404 message to handle this gracefully (for Amilia)
 ************************************************************************/
-#define MN_FIRMWARE_VERSION 2.9
+#define MN_FIRMWARE_VERSION 2.91
 
 // Our UTILITIES
 #include "mnutils.h"
@@ -886,7 +887,18 @@ int ezfClientByMemberNumber (String data) {
  * called by particleCallbackEZF()
 */
 void ezfReceiveClientByMemberNumber (const char *event, const char *data)  {
-    
+
+    // XXXX check to see if the response was a non-json error message    
+    String receivedData = String(data);
+    if(receivedData.startsWith("error status 404")) {
+        g_clientInfo.clientID = 0;
+        g_clientInfo.firstName = "Member not found";
+        g_clientInfo.isValid = true;
+
+        return;
+    }
+
+    //  XXXX legacy code is below -- we did not get an http 404 error message
     g_cibmnResponseBuffer = g_cibmnResponseBuffer + String(data);
 
     debugEvent("clientInfoPart "); // + String(data));

--- a/Software/Particle_SW/stationfirmware/src/checkinfirmware.ino
+++ b/Software/Particle_SW/stationfirmware/src/checkinfirmware.ino
@@ -156,8 +156,9 @@
  *  2.9  changes to support pictureURL coming from the CRM and being passed to the FDB. Needed for Amilia support.
  *       Fixed bug #25
  *  2.91   added test for http 404 message to handle this gracefully (for Amilia)
+ *  2.92    changed logging into message from EZ Facility to Amilia
 ************************************************************************/
-#define MN_FIRMWARE_VERSION 2.91
+#define MN_FIRMWARE_VERSION 2.92
 
 // Our UTILITIES
 #include "mnutils.h"
@@ -2293,7 +2294,8 @@ void adminGetUserInfo(int clientID, String memberNumber) {
         break;
 
     case guiIDLE: 
-        writeToLCD("Signing in","to EZFacility");
+//        writeToLCD("Signing in","to EZFacility");
+        writeToLCD("Signing in","to Amilia");   // updated for Amilia
         // request a good token from ezf
         ezfGetCheckInToken(false);
         processStartMilliseconds = millis();

--- a/Software/Particle_SW/stationfirmware/src/checkinfirmware.ino
+++ b/Software/Particle_SW/stationfirmware/src/checkinfirmware.ino
@@ -896,6 +896,12 @@ void ezfReceiveClientByMemberNumber (const char *event, const char *data)  {
         g_clientInfo.firstName = "Member not found";
         g_clientInfo.isValid = true;
 
+        // extra stuff added to 2.92 to see if we can better fake it out.
+        //  testing shows that this stuff doesn't seem to matter.
+        g_clientInfo.isError = true;   // XXXX does this matter? Doesn't seem so!
+        JSONParseError = "0";   // does this matter?  Doesn't seem so!
+        // end of extra stuff ...
+        
         return;
     }
 


### PR DESCRIPTION
Update to version 2.94: fixes the timeout issue when an admin enters an invalid member number.  The fix involves both a change to the member number query webhook and to the station firmware.