### PR TITLE
fixed checkout link on CheckedIn page. http -> https

### DIFF
--- a/Software/Facility_Database_SW/datalogging/commonfunctions.js
+++ b/Software/Facility_Database_SW/datalogging/commonfunctions.js
@@ -5,7 +5,7 @@
 
 function checkout(clientID,name) {
     var xhttp = new XMLHttpRequest();
-    var theURL = "http://rfid.makernexuswiki.com/rfidmanualcheckout.php?clientID=" + clientID 
+    var theURL = "https://rfid.makernexuswiki.com/rfidmanualcheckout.php?clientID=" + clientID 
         + "&firstName=" + encodeURI(name);
     xhttp.open("GET", theURL, true);
     xhttp.send();


### PR DESCRIPTION
This hasn't worked since we moved makernexuswiki.com to https