### PR TITLE
Improved performance of two queries

### DIFF
--- a/Software/Facility_Database_SW/datalogging/rfidcheckin.php
+++ b/Software/Facility_Database_SW/datalogging/rfidcheckin.php
@@ -60,7 +60,7 @@ $today->setTimeZone(new DateTimeZone("America/Los_Angeles"));
 
 $currentStatusSQL = 
 "SELECT * FROM rawdata 
-WHERE clientID = <<clientID>> 
+WHERE clientID = '<<clientID>>' 
   AND logEvent in ('Checked In','Checked Out')
   AND dateEventLocal > CONVERT('" . date_format($today, "Y-m-d") . "', DATE) 
 ORDER BY dateEventLocal DESC 

--- a/Software/Facility_Database_SW/datalogging/rfidcheckin.php
+++ b/Software/Facility_Database_SW/datalogging/rfidcheckin.php
@@ -62,7 +62,7 @@ $currentStatusSQL =
 "SELECT * FROM rawdata 
 WHERE clientID = <<clientID>> 
   AND logEvent in ('Checked In','Checked Out')
-  AND CONVERT( dateEventLocal, DATE) = CONVERT('" . date_format($today, "Y-m-d") . "', DATE) 
+  AND dateEventLocal > CONVERT('" . date_format($today, "Y-m-d") . "', DATE) 
 ORDER BY dateEventLocal DESC 
 LIMIT 1";
 

--- a/Software/Facility_Database_SW/datalogging/rfidcheckinout.php
+++ b/Software/Facility_Database_SW/datalogging/rfidcheckinout.php
@@ -403,7 +403,7 @@ function createRawDataInsertSQL ($dateEventLocal, $coreID, $clientID, $firstName
 function createCheckInOutStatusSQL ($clientID, $sqlDateToday, $sqlDateTomorrow) {
     $currentStatusSQL = 
     "SELECT * FROM rawdata 
-     WHERE clientID = <<clientID>> 
+     WHERE clientID = '<<clientID>>' 
        AND logEvent in ('Checked In','Checked Out')
        AND dateEventLocal BETWEEN CONVERT('<<todaydate>>', DATE) and CONVERT('<<tomorrowdate>>', DATE)
     ORDER BY recNum DESC 
@@ -432,7 +432,7 @@ function createIsMODSQL ($clientID,$sqlDateToday, $sqlDateTomorrow) {
 function createMODEligibleSQL ($clientID) {
     $selectMODEligibleSQL = 
         "SELECT * FROM clientInfo
-         WHERE clientID = <<clientID>>";
+         WHERE clientID = '<<clientID>>'";
     $selectMODEligibleSQL = str_replace("<<clientID>>", $clientID, $selectMODEligibleSQL);
     return $selectMODEligibleSQL;
 }


### PR DESCRIPTION
The SQL used to have 

`WHERE clientID = <<CLIENTID>> `

which evaluated to something like

`WHERE clientID = 567483`

The clientID field is a varchar. This clause formulation caused the database to abort an index lookup. Changed the code to 

`WHERE clientID = '<<CLIENTID>>'`

By putting the value in single quotes, the database is able to use the index on clientID.